### PR TITLE
Remove argument length limiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,17 +23,12 @@ function doAsync (object) {
       if (isFunction(target[prop])) {
         const fn = target[prop];
         return fn.length
-          ? (...args) => {
-              // Use 'undefined' for missing arguments
-              args.length = fn.length && fn.length - 1;
-              return promisify(fn).apply(target, args);
-            }
+          ? (...args) => promisify(fn).apply(target, args)
           : () => Promise.resolve(fn.call(target));
       }
       return target[prop];
     },
     apply (fn, thisValue, args) {
-      args.length = fn.length && fn.length - 1;
       return fn.length
         ? promisify(fn).apply(thisValue, args)
         : Promise.resolve(fn.call(thisValue));


### PR DESCRIPTION
Arguments of the promisified functions shouldn't be limited to the number of arguments of the original function, most importantly because `util.promisify.custom` implementations may need more arguments than the functions they are wrapping to work effectively. For example, there is no promisified version of `https.get`, so I implemented my own, but it needs two arguments as opposed to one (one for the options to be passed through, another to return the request object through a callback):

```js
https.get[util.promisify.custom] = function (options, requestCallback) {
  let resolve, reject;
  let promise = new Promise((res, rej) => {
    resolve = res;
    reject = rej
  });

  try {
    let req = https.get(options, (res) => {
      resolve(res);
    });
    requestCallback(req);
  } catch(e) {
    reject(e);
  }

  return promise;
}
```

Also, I can't think of any reason to have that argument limiting, because if a function gets extra arguments, it just ignores them.